### PR TITLE
chore(rest.service): remove unnecessary @Injectable() decorator

### DIFF
--- a/src/scripts/shared/services/rest.service.ts
+++ b/src/scripts/shared/services/rest.service.ts
@@ -4,7 +4,6 @@ import {Observable} from 'rxjs';
 import {Injectable} from 'angular2/core';
 import {Http, Request, Response, RequestMethod, RequestOptions, BaseRequestOptions} from 'angular2/http';
 
-@Injectable()
 export class RestOptions extends BaseRequestOptions {
 	constructor() {
 		super();


### PR DESCRIPTION
`@Injectable()` decorator is only needed if the service you're decorating has dependencies, so TS emits metadata.

This is explained here: http://blog.thoughtram.io/angular/2015/09/17/resolve-service-dependencies-in-angular-2.html